### PR TITLE
Use peekLast, as peek can return null while the queue still has items.

### DIFF
--- a/src/main/promhx/base/EventLoop.hx
+++ b/src/main/promhx/base/EventLoop.hx
@@ -32,7 +32,7 @@ class EventLoop {
       Retrieve the current length of the queue.
      **/
     public static inline function queueEmpty() {
-        return #if java queue.peek() == null #else queue.isEmpty() #end;
+        return #if java queue.peekLast() == null #else queue.isEmpty() #end;
     }
 
     /**


### PR DESCRIPTION
Turns out `java.vm.AtomicList.peek()` is not safe/useful at all.
Should probably report a bug. `peekLast` will work.

AtomicList is implemented with 2 pointers `head` and `tail`. Don't know why the implementer thought this would work without locking ... you can only CAS one value at a time. (Disclaimer:  I only looked at the AtomicList code for 2 minutes.)

So it's possible that head is null, while tail still has data.
Only `tail` is an atomic reference. `peekLast` returns tail and is correct.

Discovered this while testing a bunch of promises in a simple single threaded loop:

``` haxe
promhx.base.EventLoop.nextLoop = function(_) {};
// create a bunch of promises...
while (!promhx.base.EventLoop.queueEmpty()){
    promhx.base.EventLoop.f();
}
```
