### PR TITLE
Allow for rejected promise in errorPipe

### DIFF
--- a/src/main/promhx/Promise.hx
+++ b/src/main/promhx/Promise.hx
@@ -133,9 +133,13 @@ class Promise<T> extends AsyncBase<T>{
         var ret = new Promise<T>();
         catchError(function(e){
             var piped = f(e);
-            piped.then(ret._resolve);
+			piped.then(function (r:T) {
+				ret.handleResolve(r);
+			}).catchError(function (e:Dynamic) {
+				ret.reject(e);
+			});
         });
-        then(ret._resolve);
+		then(ret._resolve);
         return ret;
     }
 

--- a/src/test/promhx/TestPromise.hx
+++ b/src/test/promhx/TestPromise.hx
@@ -222,6 +222,33 @@ class TestPromise {
         });
         d1.resolve(resolved1);
     }
-
+	
+	/**
+	 * Represents a case where a 2-stage transaction fails part way through and you want to reverse the first stage.
+	 */
+	public function testTwoStageTransactionFailure(){
+		var from = Promise.promise(true);
+		var fromReversed = Promise.promise(true);
+		var to = new Promise<Bool>();
+		to.reject("Stage 2 of this transaction has failed.");
+		
+		var async = Assert.createAsync(function(){
+            Assert.isTrue(true);
+        });
+		from.pipe(function (_) {
+			return to.errorPipe(function (err) {
+				var errProm = new Promise<Bool>();
+				fromReversed.then(function (_) {
+					errProm.reject(err);
+				}).catchError(function (_) {
+					errProm.reject(err);
+				});
+				return errProm;
+			});
+		}).catchError(function (_) {
+			//This should be called
+			async();
+		});
+	}
 
 }


### PR DESCRIPTION
Added a test case that fails without the fix.